### PR TITLE
Update cdrtools to 3.01 final

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  "cdrtools-3.01a31.tar.bz2": 744d57a396e6b6dbd8010a8249a44796175bf568
+  "cdrtools-3.01.tar.bz2": 62766aa9bfeec91b3c78da7c59b5c96bfbec84d9

--- a/cdrtools.spec
+++ b/cdrtools.spec
@@ -1,10 +1,11 @@
-%define beta a31
+# Set beta to aNN (e.g. a31) if a X.XXaNN preview version was released since the latest Y.YY stable release.
+# %define beta a31
 # Build system doesn't support DI generation
 %define debug_package %{nil}
 
 Name: cdrtools
 Version: 3.01
-Release: 6
+Release: 7
 Source0: http://downloads.sourceforge.net/project/cdrtools/%{?beta:alpha/}%{name}-%{version}%{?beta:%{beta}}.tar.bz2
 Summary: Tools for working with writable CD, DVD and BluRay media
 URL: http://cdrtools.sourceforge.net/
@@ -58,6 +59,7 @@ rm -f %{buildroot}%{_bindir}/btcflash
 %post
 %{_sbindir}/setcap cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep %{_bindir}/cdrecord
 %{_sbindir}/setcap cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep %{_bindir}/cdda2wav
+%{_sbindir}/setcap cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep %{_bindir}/readcd
 
 %files
 %{_bindir}/*


### PR DESCRIPTION
Comment out the definition of beta in order to switch to the 3.01 final release.
Add a setcap for setting the capabilities of readcd to those of cdda2wav but without cap_sys_nice, as suggested by the author in AN-3.01a14 and AN-3.01.
