### PR TITLE
Update cdrtools to 3.02a01

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,2 +1,2 @@
 sources:
-  "cdrtools-3.01a23.tar.bz2": 0539be5cb1ca27754608a1ddf5b36c8587cc5ae4
+  "cdrtools-3.02a01.tar.bz2": a7fccb3b16c7a4fc49d1926d72f20ebba290029a

--- a/cdrtools.spec
+++ b/cdrtools.spec
@@ -1,14 +1,15 @@
-%define beta a23
+# Set beta to aNN (e.g. a31) if a Y.YYaNN preview version was released since the latest X.XX stable release.
+%define beta a01
 # Build system doesn't support DI generation
 %define debug_package %{nil}
 
 Name: cdrtools
-Version: 3.01
-Release: 5
-Source0: ftp://ftp.berlios.de/pub/cdrecord/alpha/%{name}-%{version}%{?beta:%{beta}}.tar.bz2
+Version: 3.02
+Release: 1
+Source0: http://downloads.sourceforge.net/project/cdrtools/%{?beta:alpha/}%{name}-%{version}%{?beta:%{beta}}.tar.bz2
 Summary: Tools for working with writable CD, DVD and BluRay media
-URL: http://cdrecord.berlios.de/
-License: Various Open Source Licenses (GPL, CDDL, BSD)
+URL: http://cdrtools.sourceforge.net/
+License: Various Open Source Licenses (CDDL, LGPL, GPL)
 Group: Archiving/Cd burning
 BuildRequires: %{_lib}cap-devel
 Obsoletes: cdrkit < 1.1.11-11
@@ -26,7 +27,7 @@ The suite includes the following programs:
   cdrecord  A CD/DVD/BD recording program 
   readcd    A program to read CD/DVD/BD media with CD-clone features 
   cdda2wav  The most evolved CD-audio extraction program with paranoia support 
-  mkisofs   A program to create hybrid ISO9660/JOLIET/HFS filesystes
+  mkisofs   A program to create hybrid ISO9660/JOLIET/HFS filesystems
             with optional Rock Ridge attributes 
   isodebug  A program to print mkisofs debug information from media 
   isodump   A program to dump ISO-9660 media 
@@ -58,6 +59,7 @@ rm -f %{buildroot}%{_bindir}/btcflash
 %post
 %{_sbindir}/setcap cap_sys_resource,cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_ipc_lock,cap_sys_rawio+ep %{_bindir}/cdrecord
 %{_sbindir}/setcap cap_dac_override,cap_sys_admin,cap_sys_nice,cap_net_bind_service,cap_sys_rawio+ep %{_bindir}/cdda2wav
+%{_sbindir}/setcap cap_dac_override,cap_sys_admin,cap_net_bind_service,cap_sys_rawio+ep %{_bindir}/readcd
 
 %files
 %{_bindir}/*


### PR DESCRIPTION
Also simplified the definition of Source0 since SourceForge yelds a redirect that works both for stable and alpha release tarballs.
